### PR TITLE
remove line_items from profile/cart response

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -156,7 +156,6 @@ class Profile(ViewSet):
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes
Delete  `cart["order"]["line_items"] = line_items.data` from profile.py, was creating duplicate entry in response. 
## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/profile/cart
**Response**

HTTP/1.1 200 OK

```json
{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Durango",
                "price": 541.17,
                "number_sold": 0,
                "description": "1998 Dodge",
                "quantity": 2,
                "created_date": "2019-05-16",
                "location": "Górki Wielkie",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

## Related Issues

- Fixes #2