### PR TITLE
fixed same profile returned bug

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
## Changes
User Id was hardcoded into `views/profile.py`.  Fixed with `current_user = Customer.objects.get(user=request.auth.user)`
## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/profile

**Response**

HTTP/1.1 200 OK

```json

{
    "id": 7,
    "url": "http://localhost:8000/customers/7",
    "user": {
        "first_name": "Brenda",
        "last_name": "Long",
        "email": "brenda@brendalong.com"
    },
    "phone_number": "555-1212",
    "address": "100 Indefatiguable Way",
    "payment_types": [
        {
            "url": "http://localhost:8000/paymenttypes/3",
            "deleted": null,
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11",
            "customer": "http://localhost:8000/customers/7"
        }
    ]
}
```

## Related Issues

- Fixes #4