### PR TITLE
increased max possible price from 10000 to 17500

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -16,7 +16,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)


### PR DESCRIPTION
Change maximum possible price to $17,500.00

## Changes

- Change value of `MaxValueValidator` to `17500` in `models/product.py`

## Requests / Responses
**Request**

POST `/products` Creates a new product

```json
{
    "id": 103,
    "name": "A Very Expensive Item",
    "price": 17500.0,
    "number_sold": 0,
    "description": "Break the bank",
    "quantity": 60,
    "created_date": "2021-02-11",
    "location": "Nashville",
    "image_path": null,
    "average_rating": 0
}
```

GET `/products/103`
RESPONSE 200 OK

```json
{
    "id": 103,
    "name": "A Very Expensive Item",
    "price": 17500.0,
    "number_sold": 0,
    "description": "Break the bank",
    "quantity": 60,
    "created_date": "2021-02-11",
    "location": "Nashville",
    "image_path": null,
    "average_rating": 0
}
```

## Related Issues
- Fixes #10