### PR TITLE
defined minimum pricer filter/query

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -248,6 +248,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        minimum_price = self.request.query_params.get('minimum_price', None)
 
         if order is not None:
             order_filter = order
@@ -271,6 +272,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if minimum_price is not None:
+            def min_price_filter(product):
+                if product.price > int(minimum_price):
+                    return True
+                return False
+            
+            products = filter(min_price_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Create a `minimum_price` filter that returns products where `price > q`

## Changes
- Added `minimum_price` filter in `views/product.py`

## Requests / Responses
GET `http://localhost:8000/products?minimum_price=17000`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 102,
        "name": "Kite",
        "price": 17500.0,
        "number_sold": 0,
        "description": "It flies high",
        "quantity": 60,
        "created_date": "2021-02-11",
        "location": "Pittsburgh",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 103,
        "name": "A Very Expensive Item",
        "price": 17500.0,
        "number_sold": 0,
        "description": "Break the bank",
        "quantity": 60,
        "created_date": "2021-02-11",
        "location": "Nashville",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Related Issues

- Fixes #9