### PR TITLE
filter products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,6 +249,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         minimum_price = self.request.query_params.get('minimum_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -280,6 +281,9 @@ class Products(ViewSet):
                 return False
             
             products = filter(min_price_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
User can get products by location

## Changes

- Added location param/filter in `views/product.py` that returns products where `location contains q`

## Requests / Responses
**Request**
GET `http://localhost:8000/products?location=Nashville`

**Response**
HTTP/1.1 200 OK

```json
[
    {
        "id": 103,
        "name": "A Very Expensive Item",
        "price": 17500.0,
        "number_sold": 0,
        "description": "Break the bank",
        "quantity": 60,
        "created_date": "2021-02-11",
        "location": "Nashville",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Related Issues
- Fixes #12