### PR TITLE
fixed incorrect expiration date

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -35,8 +35,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
PR fixes payment type information

## Changes

- In the `Create` method in `views/paymenttype.py`,  `new_payment.expiration_date` was using `create_date` from the response, vice versa. 

## Requests / Responses
**Request**

POST `http://localhost:8000/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Matt's Bank Account",
    "account_number": "000000000000",
    "expiration_date": "2050-12-25",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 Created
```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Matt's Bank Account",
    "account_number": "000000000000",
    "expiration_date": "2050-12-25",
    "create_date": "2020-12-12"
}
```

## Related Issues

- Fixes #7