### PR TITLE
created test for deleting payment

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Payment
 
 
 class PaymentTests(APITestCase):
@@ -40,4 +41,18 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+
+    def test_delete_payment(self):
+        payment = Payment()
+        payment.merchant_name = "American Express"
+        payment.account_number = "111-1111-1111"
+        payment.expiration_date = "2024-12-31"
+        payment.create_date = datetime.date.today()
+        payment.customer_id = 1
+        payment.save()
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(f"/paymenttypes/{payment.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.get(f"/paymenttypes/{payment.id}")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Create integration test to verify user can delete a payment type.

## Changes

- Added `Delete` integration test in `tests/payments.py`

## Test Passed

```
Ran 8 tests in 0.975s

OK
Destroying test database for alias 'default'...
```

## Related Issues

- Fixes #17