### PR TITLE
add prodcuct to new order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -108,4 +108,12 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["payment_type"], "http://testserver/paymenttypes/1")
 
 
-     # TODO: New line item is not added to closed order
+    def test_item_added_new_order(self):
+        self.test_add_product_to_order()
+
+        url = "/orders/1"
+
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["payment_type"], None)


### PR DESCRIPTION
Added integration test to make sure items are not added to a closed order

## Changes
Added `test_item_added_new_order()` in `tests/order`

## Successful Test
```
Ran 10 tests in 0.972s

OK
Destroying test database for alias 'default'...
```

## Related Issues
- Fixes #16